### PR TITLE
Add missing annotations to use qt5 version of qdbusxml2cpp

### DIFF
--- a/src/dbus/org.freedesktop.login1.LDManager.xml
+++ b/src/dbus/org.freedesktop.login1.LDManager.xml
@@ -22,21 +22,25 @@
       <arg name="seat" type="o" direction="out"/>
     </method>
     <method name="ListSessions">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="LoginDBusSessionList"/>
       <arg name="sessions" type="a(susso)" direction="out">
           <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="LoginDBusSessionList"/>
       </arg>
     </method>
     <method name="ListUsers">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="LoginDBusUserList"/>
       <arg name="users" type="a(uso)" direction="out">
           <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="LoginDBusUserList"/>
       </arg>
     </method>
     <method name="ListSeats">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="LoginDBusSeatList"/>
       <arg name="seats" type="a(so)" direction="out">
           <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="LoginDBusSeatList"/>
       </arg>
     </method>
     <method name="CreateSession">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.In11" value="LoginDBusScopePropertyList"/>
       <arg name="uid" type="u" direction="in"/>
       <arg name="leader" type="u" direction="in"/>
       <arg name="service" type="s" direction="in"/>
@@ -147,6 +151,7 @@
       <arg name="fd" type="h" direction="out"/>
     </method>
     <method name="ListInhibitors">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="LoginDBusInhibitorList"/>
       <arg name="inhibitors" type="a(ssssuu)" direction="out">
           <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="LoginDBusInhibitorList"/>
       </arg>

--- a/src/dbus/org.freedesktop.systemd1.Manager.xml
+++ b/src/dbus/org.freedesktop.systemd1.Manager.xml
@@ -99,14 +99,16 @@
   <method name="ClearJobs"/>
   <method name="ResetFailed"/>
   <method name="ListUnits">
-   <arg name="units" type="a(ssssssouso)" direction="out">
     <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="ManagerDBusUnitList"/>
-   </arg>
+    <arg name="units" type="a(ssssssouso)" direction="out">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="ManagerDBusUnitList"/>
+     </arg>
   </method>
   <method name="ListJobs">
-   <arg name="jobs" type="a(usssoo)" direction="out">
     <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="ManagerDBusJobList"/>
-   </arg>
+    <arg name="jobs" type="a(usssoo)" direction="out">
+      <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="ManagerDBusJobList"/>
+     </arg>
   </method>
   <method name="Subscribe"/>
   <method name="Unsubscribe"/>
@@ -143,6 +145,7 @@
    <arg name="set" type="as" direction="in"/>
   </method>
   <method name="ListUnitFiles">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="DBusUnitFileListList"/>
    <arg name="files" type="a(ss)" direction="out">
     <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="DBusUnitFileListList"/>
    </arg>
@@ -152,6 +155,7 @@
    <arg name="state" type="s" direction="out"/>
   </method>
   <method name="EnableUnitFiles">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="DBusUnitFileChangeList"/>
    <arg name="files" type="as" direction="in"/>
    <arg name="runtime" type="b" direction="in"/>
    <arg name="force" type="b" direction="in"/>
@@ -161,6 +165,7 @@
    </arg>
   </method>
   <method name="DisableUnitFiles">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="DBusUnitFileChangeList"/>
    <arg name="files" type="as" direction="in"/>
    <arg name="runtime" type="b" direction="in"/>
    <arg name="changes" type="a(sss)" direction="out">
@@ -168,6 +173,7 @@
    </arg>
   </method>
   <method name="ReenableUnitFiles">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="DBusUnitFileChangeList"/>
    <arg name="files" type="as" direction="in"/>
    <arg name="runtime" type="b" direction="in"/>
    <arg name="force" type="b" direction="in"/>
@@ -177,6 +183,7 @@
    </arg>
   </method>
   <method name="LinkUnitFiles">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="DBusUnitFileChangeList"/>
    <arg name="files" type="as" direction="in"/>
    <arg name="runtime" type="b" direction="in"/>
    <arg name="force" type="b" direction="in"/>
@@ -185,6 +192,7 @@
    </arg>
   </method>
   <method name="PresetUnitFiles">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="DBusUnitFileChangeList"/>
    <arg name="files" type="as" direction="in"/>
    <arg name="runtime" type="b" direction="in"/>
    <arg name="force" type="b" direction="in"/>
@@ -194,6 +202,7 @@
    </arg>
   </method>
   <method name="MaskUnitFiles">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="DBusUnitFileChangeList"/>
    <arg name="files" type="as" direction="in"/>
    <arg name="runtime" type="b" direction="in"/>
    <arg name="force" type="b" direction="in"/>
@@ -202,6 +211,7 @@
    </arg>
   </method>
   <method name="UnmaskUnitFiles">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="DBusUnitFileChangeList"/>
    <arg name="files" type="as" direction="in"/>
    <arg name="runtime" type="b" direction="in"/>
    <arg name="changes" type="a(sss)" direction="out">
@@ -209,6 +219,7 @@
    </arg>
   </method>
   <method name="SetDefaultTarget">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="DBusUnitFileChangeList"/>
    <arg name="files" type="as" direction="in"/>
    <arg name="changes" type="a(sss)" direction="out">
     <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="DBusUnitFileChangeList"/>
@@ -218,6 +229,7 @@
    <arg name="name" type="s" direction="out"/>
   </method>
   <method name="SetUnitProperties">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="DBusUnitFilePropertyList"/>
    <arg name="name" type="s" direction="in"/>
    <arg name="runtime" type="b" direction="in"/>
    <arg name="properties" type="a(sv)" direction="in">
@@ -225,6 +237,8 @@
    </arg>
   </method>
   <method name="StartTransientUnit">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="DBusUnitFilePropertyList"/>
+   <annotation name="org.qtproject.QtDBus.QtTypeName.In3" value="ManagerDBusAuxList"/>
    <arg name="name" type="s" direction="in"/>
    <arg name="mode" type="s" direction="in"/>
    <arg name="properties" type="a(sv)" direction="in">

--- a/src/dbus/org.freedesktop.systemd1.Unit.xml
+++ b/src/dbus/org.freedesktop.systemd1.Unit.xml
@@ -36,6 +36,7 @@
   </method>
   <method name="ResetFailed"/>
   <method name="SetProperties">
+   <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="DBusUnitFilePropertyList"/>
    <arg name="runtime" type="b" direction="in"/>
    <arg name="properties" type="a(sv)" direction="in">
     <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="DBusUnitFilePropertyList"/>


### PR DESCRIPTION
Qt5 needs the annotations at a different scope, add them and leave the old one for companbility
