### PR TITLE
Add support for creating transient units in user sessions

### DIFF
--- a/src/generic-types.cpp
+++ b/src/generic-types.cpp
@@ -18,7 +18,31 @@
  */
 
 #include "generic-types.h"
+#include <QDBusMetaType>
 
+static int dbus_types[] = {
+    qDBusRegisterMetaType<DBusUnit>(),
+    qDBusRegisterMetaType<DBusJob>(),
+    qDBusRegisterMetaType<UnitDBusProperty>(),
+    qDBusRegisterMetaType<UnitDBusPropertyList>(),
+    qDBusRegisterMetaType<ManagerDBusAux>(),
+    qDBusRegisterMetaType<ManagerDBusAuxList>(),
+    qDBusRegisterMetaType<UnitDBusExecCommand>(),
+    qDBusRegisterMetaType<UnitDBusExecCommandList>(),
+    qDBusRegisterMetaType<ManagerDBusUnitFileChange>(),
+    qDBusRegisterMetaType<ManagerDBusUnitFileChangeList>(),
+    qDBusRegisterMetaType<ManagerDBusJob>(),
+    qDBusRegisterMetaType<ManagerDBusJobList>(),
+    qDBusRegisterMetaType<ManagerDBusUnit>(),
+    qDBusRegisterMetaType<ManagerDBusUnitList>(),
+    qDBusRegisterMetaType<ManagerDBusUnitFile>(),
+    qDBusRegisterMetaType<ManagerDBusUnitFileList>(),
+    qDBusRegisterMetaType<DBusSession>(),
+    qDBusRegisterMetaType<DBusSessionList>(),
+    qDBusRegisterMetaType<DBusSeat>(),
+    qDBusRegisterMetaType<DBusSeatList>(),
+
+};
 
 QDBusArgument& operator<<(QDBusArgument &argument, const DBusJob &job)
 {
@@ -471,16 +495,19 @@ const QDBusArgument& operator>>(const QDBusArgument &argument, UnitDBusLoadError
 QDBusArgument& operator<<(QDBusArgument &argument, const UnitDBusProperty &property)
 {
     argument.beginStructure();
-    argument << property.name << property.value.toString();
+    argument << property.name << QDBusVariant(property.value);
     argument.endStructure();
     return argument;
 }
 
 const QDBusArgument& operator>>(const QDBusArgument &argument, UnitDBusProperty &property)
 {
+    QDBusVariant value;
     argument.beginStructure();
-    argument >> property.name >> property.value;
+    argument >> property.name >> value;
     argument.endStructure();
+
+    property.value = value.variant();
     return argument;
 }
 
@@ -496,6 +523,24 @@ const QDBusArgument& operator>>(const QDBusArgument &argument, ManagerDBusAux &a
 {
     argument.beginStructure();
     argument >> aux.name >> aux.properties;
+    argument.endStructure();
+    return argument;
+}
+
+
+QDBusArgument &operator<<(QDBusArgument &argument, const UnitDBusExecCommand &execCommand)
+{
+    argument.beginStructure();
+    argument << execCommand.path << execCommand.argv << execCommand.ignore;
+    argument.endStructure();
+    return argument;
+}
+
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, UnitDBusExecCommand &execCommand)
+{
+    argument.beginStructure();
+    argument >> execCommand.path >> execCommand.argv >> execCommand.ignore;
     argument.endStructure();
     return argument;
 }

--- a/src/generic-types.h
+++ b/src/generic-types.h
@@ -154,6 +154,19 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, ExecuteDBusExecCo
 
 typedef struct
 {
+    QString path;
+    QList<QString> argv;
+    bool ignore;
+} UnitDBusExecCommand;
+Q_DECLARE_METATYPE(UnitDBusExecCommand)
+typedef QList<UnitDBusExecCommand> UnitDBusExecCommandList;
+Q_DECLARE_METATYPE(UnitDBusExecCommandList)
+
+QDBusArgument &operator<<(QDBusArgument &argument, const UnitDBusExecCommand &execCommand);
+const QDBusArgument &operator>>(const QDBusArgument &argument, UnitDBusExecCommand &execCommand);
+
+typedef struct
+{
     bool ignore;
     QString context;
 } ExecuteDBusSELinuxContext;

--- a/src/job.cpp
+++ b/src/job.cpp
@@ -20,8 +20,8 @@
 #include "job_p.h"
 #include "sdmanager_p.h"
 
-Systemd::JobPrivate::JobPrivate(const QString &path) :
-    jobIface(Systemd::SystemdPrivate::SD_DBUS_SERVICE, path, QDBusConnection::systemBus())
+Systemd::JobPrivate::JobPrivate(const QString &path, const QDBusConnection &connection) :
+    jobIface(Systemd::SystemdPrivate::SD_DBUS_SERVICE, path, connection)
 {
     id = jobIface.id();
     jobType = jobIface.jobType();
@@ -33,8 +33,8 @@ Systemd::JobPrivate::~JobPrivate()
 {
 }
 
-Systemd::Job::Job(const QString &path, QObject *parent) :
-                  QObject(parent), d_ptr(new JobPrivate(path))
+Systemd::Job::Job(const QString &path, const QDBusConnection &connection, QObject *parent) :
+                  QObject(parent), d_ptr(new JobPrivate(path, connection))
 {
 }
 

--- a/src/job.h
+++ b/src/job.h
@@ -24,6 +24,8 @@
 
 #include "QtSystemd-export.h"
 
+class QDBusConnection;
+
 namespace Systemd {
 
 class JobPrivate;
@@ -36,7 +38,7 @@ class SDQT_EXPORT Job : public QObject
 public:
     typedef QSharedPointer<Job> Ptr;
 
-    explicit Job(const QString &path, QObject *parent = 0);
+    explicit Job(const QString &path, const QDBusConnection &connection, QObject *parent = 0);
     explicit Job(JobPrivate &job, QObject *parent = 0);
     virtual ~Job();
 

--- a/src/job_p.h
+++ b/src/job_p.h
@@ -30,7 +30,7 @@ class JobPrivate
 {
 
 public:
-    explicit JobPrivate(const QString &path);
+    explicit JobPrivate(const QString &path, const QDBusConnection &connection);
     virtual ~JobPrivate();
 
     OrgFreedesktopSystemd1JobInterface jobIface;

--- a/src/ldmanager.cpp
+++ b/src/ldmanager.cpp
@@ -48,12 +48,12 @@ Systemd::Logind::LogindPrivate::~LogindPrivate()
 
 void Systemd::Logind::LogindPrivate::init()
 {
-    qDBusRegisterMetaType<DBusSeat>;
+
 }
 
 QList<Systemd::Logind::Seat *> Systemd::Logind::LogindPrivate::listSeats()
 {
-    qDBusRegisterMetaType<DBusSeatList>;
+
     QDBusPendingReply<DBusSeatList> reply = ildface.ListSeats();
     reply.waitForFinished();
 

--- a/src/sdmanager.h
+++ b/src/sdmanager.h
@@ -21,7 +21,7 @@
 #define SD_MANAGER_H
 
 #include <QStringList>
-
+#include <QMultiMap>
 #include "QtSystemd-export.h"
 
 #include "job.h"
@@ -36,6 +36,11 @@
  */
 namespace Systemd
 {
+    enum SessionType {
+        SystemSession,
+        UserSession,
+    };
+
     enum Mode {
         Replace,
         Fail,
@@ -97,73 +102,73 @@ namespace Systemd
      * Disables one or more units in the system, i.e. removes all symlinks to
      * them in /etc and /run.
      */
-    SDQT_EXPORT void disableUnitFiles(const QStringList &files, const bool runtime);
+    SDQT_EXPORT void disableUnitFiles( const SessionType &session, const QStringList &files, const bool runtime);
 
     /*
      * May be used to enable one or more units in the system (by creating
      * symlinks to them in /etc or /run).
      */
-    SDQT_EXPORT void enableUnitFiles(const QStringList &files, const bool runtime, const bool force);
+    SDQT_EXPORT void enableUnitFiles( const SessionType &session, const QStringList &files, const bool runtime, const bool force);
 
     /*
      * Returns the job object path for a specific job, identified by its id.
      */
-    SDQT_EXPORT Job::Ptr getJob(const uint id);
+    SDQT_EXPORT Job::Ptr getJob( const SessionType &session, const uint id);
 
     /*
      * May be used to get the unit object path for a unit name. It takes the
      * unit name and returns the object path. If a unit has not been loaded
      * yet by this name this call will fail.
      */
-    SDQT_EXPORT Unit::Ptr getUnit(const QString &name);
+    SDQT_EXPORT Unit::Ptr getUnit( const SessionType &session, const QString &name);
 
     /*
      * May be used to get the unit object path of the unit a process ID
      * belongs to. Takes a Unix PID and returns the object path. The PID must
      * refer to an existing process of the system.
      */
-    SDQT_EXPORT Unit::Ptr getUnitByPID(const uint pid);
+    SDQT_EXPORT Unit::Ptr getUnitByPID( const SessionType &session, const uint pid);
 
     /*
      * Returns the current enablement status of specific unit file.
      */
-    SDQT_EXPORT QString getUnitFileState(const QString &file);
+    SDQT_EXPORT QString getUnitFileState( const SessionType &session, const QString &file);
 
     /*
      * May be used to kill (i.e. send a signal to) all processes of a unit.
      */
-    SDQT_EXPORT void killUnit(const QString &name, const Systemd::Who who, const int signal);
+    SDQT_EXPORT void killUnit( const SessionType &session, const QString &name, const Systemd::Who who, const int signal);
 
     /*
      * Returns an array with all currently queued jobs.
      */
-    SDQT_EXPORT QList<Job::Ptr> listJobs();
+    SDQT_EXPORT QList<Job::Ptr> listJobs( const SessionType &session );
 
     /*
      * Returns an array with all currently loaded units. Note that units may
      * be known by multiple names at the same name, and hence there might be
      * more unit names loaded than actual units behind them.
      */
-    SDQT_EXPORT QList<Unit::Ptr> listUnits();
+    SDQT_EXPORT QList<Unit::Ptr> listUnits(  const SessionType &session );
 
     /*
      * Returns an array of unit names. Note that listUnit() returns a list of
      * units currently loaded into memory, while listUnitFiles() returns a
      * list of unit files that could be found on disk.
      */
-    SDQT_EXPORT QStringList listUnitFiles();
+    SDQT_EXPORT QStringList listUnitFiles(  const SessionType &session );
 
     /*
      * Is similar to getUnit() but will load the unit from disk if possible.
      */
-    SDQT_EXPORT Unit::Ptr loadUnit(const QString &name);
+    SDQT_EXPORT Unit::Ptr loadUnit( const SessionType &session, const QString &name);
 
     /*
      * May be used to reload a unit, and takes similar arguments as
      * startUnit(). Reloading is done only if the unit is already running and
      * fails otherwise.
      */
-    SDQT_EXPORT Job::Ptr reloadUnit(const QString &name, const Mode mode);
+    SDQT_EXPORT Job::Ptr reloadUnit( const SessionType &session, const QString &name, const Mode mode);
 
     /*
      * Is similar to reloadUnit() but will restart the unit. If a service is
@@ -171,23 +176,30 @@ namespace Systemd
      * flavor is used in which case a service that isn't running is not
      * affected by the restart.
      */
-    SDQT_EXPORT Job::Ptr restartUnit(const QString &name, const Mode mode);
+    SDQT_EXPORT Job::Ptr restartUnit( const SessionType &session, const QString &name, const Mode mode);
 
     /*
      * Enqeues a start job, and possibly depending jobs. Takes the unit to
      * activate, plus a mode string.
      */
-    SDQT_EXPORT Job::Ptr startUnit(const QString &name, const Mode mode);
+    SDQT_EXPORT Job::Ptr startUnit( const SessionType &session, const QString &name, const Mode mode);
+
+    /*
+     * Enqeues a start job for a transient unit, and possibly depending jobs.
+     * Takes a string for the new unit's name, a mode string, and a multimap
+     * of properties to be set for the unit.
+     */
+    SDQT_EXPORT Job::Ptr startTransientUnit( const SessionType &session, const QString &name, const Mode mode, const QMultiMap<QString,QVariant> &properties);
 
     /*
      * Is similar to startUnit() but stops the specified unit rather than
      * starting it. Note that "isolate" mode is invalid for this call.
      */
-    SDQT_EXPORT Job::Ptr stopUnit(const QString &name, const Mode mode);
+    SDQT_EXPORT Job::Ptr stopUnit( const SessionType &session, const QString &name, const Mode mode);
 
-    SDQT_EXPORT void resetFailedUnit(const QString &name);
+    SDQT_EXPORT void resetFailedUnit( const SessionType &session, const QString &name);
 
-    SDQT_EXPORT Notifier* notifier();
+    SDQT_EXPORT Notifier* notifier(const SessionType &session);
 }
 
 #endif

--- a/src/sdmanager_p.h
+++ b/src/sdmanager_p.h
@@ -24,6 +24,8 @@
 
 #include "sdmanager.h"
 
+class QDBusConnection;
+
 namespace Systemd {
 
 class SystemdPrivate : public Notifier
@@ -34,7 +36,7 @@ public:
     static const QString SD_DBUS_SERVICE;
     static const QString SD_DBUS_DAEMON_PATH;
 
-    SystemdPrivate();
+    SystemdPrivate(const QDBusConnection &connection);
     ~SystemdPrivate();
     OrgFreedesktopSystemd1ManagerInterface isdface;
 
@@ -52,6 +54,7 @@ public:
     Job::Ptr reloadUnit(const QString &name, const Mode mode);
     Job::Ptr restartUnit(const QString &name, const Mode mode);
     Job::Ptr startUnit(const QString &name, const Mode mode);
+    Job::Ptr startTransientUnit(const QString &name, const Mode mode, const QMultiMap<QString,QVariant> &properties);
     Job::Ptr stopUnit(const QString &name, const Mode mode);
     void resetFailedUnit(const QString &name);
 
@@ -68,6 +71,19 @@ private:
     Result stringToResult(const QString &result);
     void init();
 };
+
+
+class ManagerSystemSession : public SystemdPrivate {
+public:
+    ManagerSystemSession();
+};
+
+class ManagerUserSession : public SystemdPrivate {
+public:
+    ManagerUserSession();
+};
+
+
 }
 
 #endif

--- a/src/seat.cpp
+++ b/src/seat.cpp
@@ -23,9 +23,6 @@
 Systemd::Logind::SeatPrivate::SeatPrivate(const QString &path) :
     seatIface(Systemd::Logind::LogindPrivate::LD_DBUS_SERVICE, path, QDBusConnection::systemBus())
 {
-    qDBusRegisterMetaType<DBusSession>;
-    qDBusRegisterMetaType<DBusSessionList>;
-
     activeSession = seatIface.activeSession();
     canGraphical = seatIface.canGraphical();
     canMultiSession = seatIface.canMultiSession();

--- a/src/unit.cpp
+++ b/src/unit.cpp
@@ -16,12 +16,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  */
-
+#include <QDBusConnection>
 #include "unit_p.h"
 #include "sdmanager_p.h"
 
-Systemd::UnitPrivate::UnitPrivate(const QString &path) :
-    unitIface(Systemd::SystemdPrivate::SD_DBUS_SERVICE, path, QDBusConnection::systemBus())
+Systemd::UnitPrivate::UnitPrivate(const QString &path, const QDBusConnection &connection) :
+    unitIface(Systemd::SystemdPrivate::SD_DBUS_SERVICE, path, connection)
 {
     activeEnterTimestamp = unitIface.activeEnterTimestamp();
     activeEnterTimestampMonotonic = unitIface.activeEnterTimestampMonotonic();
@@ -93,8 +93,8 @@ Systemd::UnitPrivate::~UnitPrivate()
 {
 }
 
-Systemd::Unit::Unit(const QString &path, QObject *parent) :
-                    QObject(parent), d_ptr(new UnitPrivate(path))
+Systemd::Unit::Unit(const QString &path, const QDBusConnection &connection, QObject *parent) :
+                    QObject(parent), d_ptr(new UnitPrivate(path,connection))
 {
 }
 

--- a/src/unit.h
+++ b/src/unit.h
@@ -25,6 +25,7 @@
 
 #include "QtSystemd-export.h"
 
+class QDBusConnection;
 namespace Systemd {
 
 class UnitPrivate;
@@ -37,7 +38,7 @@ class SDQT_EXPORT Unit : public QObject
 public:
     typedef QSharedPointer<Unit> Ptr;
 
-    explicit Unit(const QString &path, QObject *parent = 0);
+    explicit Unit(const QString &path, const QDBusConnection &connection, QObject *parent = 0);
     explicit Unit(UnitPrivate &unit, QObject *parent = 0);
     virtual ~Unit();
 

--- a/src/unit_p.h
+++ b/src/unit_p.h
@@ -30,7 +30,7 @@ class UnitPrivate
 {
 
 public:
-    explicit UnitPrivate(const QString &path);
+    explicit UnitPrivate(const QString &path, const QDBusConnection &connection);
     virtual ~UnitPrivate();
 
     OrgFreedesktopSystemd1UnitInterface unitIface;

--- a/tests/sdmanager-test.cpp
+++ b/tests/sdmanager-test.cpp
@@ -21,6 +21,7 @@
 #include <QCoreApplication>
 
 #include "../src/sdmanager.h"
+#include "../src/generic-types.h"
 
 using namespace Systemd;
 
@@ -32,7 +33,7 @@ public:
         f << QLatin1String("upower.service");
 
         qDebug() << f;
-        Systemd::disableUnitFiles(f, false);;
+        Systemd::disableUnitFiles(Systemd::SystemSession, f, false);;
     }
 
     static void enableUnitFiles()
@@ -41,63 +42,84 @@ public:
         f << QLatin1String("mysqld.service");
 
         qDebug() << f;
-        Systemd::enableUnitFiles(f, false, false);
+        Systemd::enableUnitFiles(Systemd::SystemSession, f, false, false);
     }
 
     static void getUnit()
     {
-        qDebug() << Systemd::getUnit("mysqld.service")->id();
+        qDebug() << Systemd::getUnit(Systemd::SystemSession, "mysqld.service")->id();
     }
 
     static void getUnitByPID()
     {
-        qDebug() << Systemd::getUnitByPID(31493)->id();
+        qDebug() << Systemd::getUnitByPID(Systemd::SystemSession, 31493)->id();
     }
 
     static void listJobs()
     {
-        Q_FOREACH(const Job::Ptr &job, Systemd::listJobs()) {
+        Q_FOREACH(const Job::Ptr &job, Systemd::listJobs(Systemd::SystemSession)) {
             qDebug() << job->id();
         }
     }
 
     static void listUnits()
     {
-        Q_FOREACH(const Unit::Ptr &unit, Systemd::listUnits()) {
+        Q_FOREACH(const Unit::Ptr &unit, Systemd::listUnits(Systemd::SystemSession)) {
             qDebug() << unit->id();
         }
     }
 
     static void listUnitFiles()
     {
-        Q_FOREACH(const QString &unit, Systemd::listUnitFiles()) {
+        Q_FOREACH(const QString &unit, Systemd::listUnitFiles(Systemd::SystemSession)) {
             qDebug() << unit;
         }
     }
 
     static void loadUnit()
     {
-        qDebug() << Systemd::loadUnit("mysqld.service")->loadState();
+        qDebug() << Systemd::loadUnit(Systemd::SystemSession, "mysqld.service")->loadState();
     }
 
     static void reloadUnit()
     {
-        qDebug() << Systemd::reloadUnit(QLatin1String("mysqld.service"), Systemd::Replace);
+        qDebug() << Systemd::reloadUnit(Systemd::SystemSession, QLatin1String("mysqld.service"), Systemd::Replace);
     }
 
     static void restartUnit()
     {
-        qDebug() << Systemd::restartUnit(QLatin1String("mysqld.service"), Systemd::Replace);
+        qDebug() << Systemd::restartUnit(Systemd::SystemSession, QLatin1String("mysqld.service"), Systemd::Replace);
     }
 
     static void startUnit()
     {
-        qDebug() << Systemd::startUnit(QLatin1String("mysqld.service"), Systemd::Replace);
+        qDebug() << Systemd::startUnit(Systemd::SystemSession, QLatin1String("mysqld.service"), Systemd::Replace);
+    }
+
+    static void startTransientUnit()
+    {
+        QMultiMap<QString,QVariant> props;
+        UnitDBusExecCommand xterm = {0};
+        xterm.path = QLatin1String("/usr/sbin/xterm");
+        xterm.argv << QLatin1String("/usr/sbin/xterm");
+        xterm.ignore = false;
+
+        UnitDBusExecCommandList args;
+        args << xterm;
+
+        props.insert(QLatin1String("Description"), QLatin1String("Test scope") );
+        props.insert(QLatin1String("RemainAfterExit"), true );
+        props.insert(QLatin1String("Environment"), QStringList(QLatin1String("DISPLAY=:0")));
+        props.insert(QLatin1String("ExecStart"), QVariant::fromValue(args));
+
+        qDebug() << Systemd::startTransientUnit(Systemd::UserSession, QLatin1String("mycool.service"), Systemd::Fail, props);
+
+
     }
 
     static void stopUnit()
     {
-        qDebug() << Systemd::stopUnit(QLatin1String("mysqld.service"), Systemd::Replace);
+        qDebug() << Systemd::stopUnit(Systemd::SystemSession, QLatin1String("mysqld.service"), Systemd::Replace);
     }
 };
 
@@ -113,11 +135,11 @@ int main(int argc, char* argv[])
 
 //     SDManagerTest::getUnitByPID();
 
-//    SDManagerTest::listJobs();
+//     SDManagerTest::listJobs();
 
-    SDManagerTest::listUnits();
+//     SDManagerTest::listUnits();
 
-    SDManagerTest::listUnitFiles();
+//     SDManagerTest::listUnitFiles();
 
 //     SDManagerTest::loadUnit();
 
@@ -126,6 +148,8 @@ int main(int argc, char* argv[])
 //     SDManagerTest::restartUnit();
 
 //     SDManagerTest::startUnit();
+
+       SDManagerTest::startTransientUnit();
 
 //     SDManagerTest::stopUnit();
 }


### PR DESCRIPTION
This is a bit larger than it should have been, but I got a little carried away with what I considered cleanup.  (I know in the eye of the beholder).  At any rate the goal here was to be able to create a transient unit as a user.  To do this I made the following changes:

1. Refactored all qDBusRegisterMetaType calls into a single static
instance.
2. Added the notion of a System session and a User session instance
3. Exposed the DBus method to create transient units via the API.

I am not happy with how the System, or User session is selected, but I am not sure how best to do it without adding tons of duplication.  Any suggestions on improvements are more than welcome.  My goal is to use this inside of a systemd based launcher in the user session, so I may be moving in a direction away from this libraries intent.