### PR TITLE
registered missing qdbus metatypes

### DIFF
--- a/src/sdmanager.cpp
+++ b/src/sdmanager.cpp
@@ -134,6 +134,9 @@ Unit::Ptr SystemdPrivate::getUnit(const QString &name)
 {
     Unit::Ptr unit;
 
+    qDBusRegisterMetaType<UnitCondition>();
+    qDBusRegisterMetaType<UnitConditionList>();
+    qDBusRegisterMetaType<UnitLoadError>();
     QDBusPendingReply<QDBusObjectPath> reply = isdface.GetUnit(name);
     reply.waitForFinished();
 


### PR DESCRIPTION
This removes warnings about missing datatype like:
`QDBusAbstractInterface: type UnitConditionList must be registered with Qt D-Bus before it can be used to read property org.freedesktop.systemd1.Unit.Conditions`